### PR TITLE
Nested Suites

### DIFF
--- a/src/main/scala/org/podval/tools/test/filter/TestFilterPatterns.scala
+++ b/src/main/scala/org/podval/tools/test/filter/TestFilterPatterns.scala
@@ -8,7 +8,10 @@ final class TestFilterPatterns(patterns: Set[TestFilterPattern]):
       val result: Set[TestFilterPatternMatch] = patterns.flatMap(_.matchClass(className))
       if result.isEmpty then None else
         if result.contains(TestFilterPatternMatch.Suite)
-        then Some(SuiteTestFilterMatch(explicitlySpecified = true))
+        // Even when a class is singled out by name,
+        // `explicitlySpecified` should be `false`;
+        // see https://github.com/dubinsky/scalajs-gradle/issues/32
+        then Some(SuiteTestFilterMatch(explicitlySpecified = false))
         else Some(TestsTestFilterMatch(
           testNames     = for case TestFilterPatternMatch.TestName    (testName    ) <- result yield testName,
           testWildCards = for case TestFilterPatternMatch.TestWildCard(testWildCard) <- result yield testWildCard

--- a/src/test/scala/org/podval/tools/test/filter/TestFilterTest.scala
+++ b/src/test/scala/org/podval/tools/test/filter/TestFilterTest.scala
@@ -13,10 +13,10 @@ class TestFilterTest extends AnyFlatSpec, TableDrivenPropertyChecks, Matchers:
       ("input", "className", "match"),
 
       // all tests in a package
-      ("some.package.*", "some.package.Foo", Some(SuiteTestFilterMatch(true))),
-      ("some.package*", "some.package.Foo", Some(SuiteTestFilterMatch(true))),
-      ("some.package*", "some.package.sub.Foo", Some(SuiteTestFilterMatch(true))),
-      ("some.package*", "some.package1.Foo", Some(SuiteTestFilterMatch(true))),
+      ("some.package.*", "some.package.Foo", Some(SuiteTestFilterMatch(false))),
+      ("some.package*", "some.package.Foo", Some(SuiteTestFilterMatch(false))),
+      ("some.package*", "some.package.sub.Foo", Some(SuiteTestFilterMatch(false))),
+      ("some.package*", "some.package1.Foo", Some(SuiteTestFilterMatch(false))),
       ("some.package*", "some.other.package.Foo", None),
 
       // method in a package
@@ -24,12 +24,12 @@ class TestFilterTest extends AnyFlatSpec, TableDrivenPropertyChecks, Matchers:
       ("some.package*.some*", "some.package.Foo", Some(TestsTestFilterMatch(Set.empty, Set("some")))),
 
       // all tests in some class
-      ("SomeClass", "SomeClass", Some(SuiteTestFilterMatch(true))),
-      ("some.package.SomeClass", "some.package.SomeClass", Some(SuiteTestFilterMatch(true))),
+      ("SomeClass", "SomeClass", Some(SuiteTestFilterMatch(false))),
+      ("some.package.SomeClass", "some.package.SomeClass", Some(SuiteTestFilterMatch(false))),
 
       // all tests in some class in any package
-      ("SomeClass", "any.package.SomeClass", Some(SuiteTestFilterMatch(true))),
-      ("*.SomeClass", "any.package.SomeClass", Some(SuiteTestFilterMatch(true))),
+      ("SomeClass", "any.package.SomeClass", Some(SuiteTestFilterMatch(false))),
+      ("*.SomeClass", "any.package.SomeClass", Some(SuiteTestFilterMatch(false))),
 
       // single specified test in some class
       ("SomeClass.someMethod", "SomeClass", Some(TestsTestFilterMatch(Set("someMethod"), Set.empty))),
@@ -47,7 +47,7 @@ class TestFilterTest extends AnyFlatSpec, TableDrivenPropertyChecks, Matchers:
       ("org.gradle.SomeTestClass.some method containing spaces", "org.gradle.SomeTestClass", Some(TestsTestFilterMatch(Set("some method containing spaces"), Set.empty))),
 
       // include all integration tests
-      ("*IntegTest", "XIntegTest", Some(SuiteTestFilterMatch(true))),
+      ("*IntegTest", "XIntegTest", Some(SuiteTestFilterMatch(false))),
 
       // include specific method in any of the tests
       // TODO     ("*UiCheck", "Foo", Some(Matches.Tests(true, Set.empty, Set("UiCheck")))) // TODO [filter]

--- a/src/test/scala/org/podval/tools/test/framework/ScalaTestFixture.scala
+++ b/src/test/scala/org/podval/tools/test/framework/ScalaTestFixture.scala
@@ -48,15 +48,6 @@ object ScalaTestFixture extends Fixture(
          |  }
          |}
          |""".stripMargin
-    ),
-    SourceFile("ScalaTestNested",
-      s"""import org.scalatest._
-         |
-         |class ScalaTestNested extends Suites(
-         |  new ScalaTestTest,
-         |  //  new StackSpec
-         |)
-         |""".stripMargin
     )
   )
 ):

--- a/src/test/scala/org/podval/tools/test/nested/NestedSuitesTest.scala
+++ b/src/test/scala/org/podval/tools/test/nested/NestedSuitesTest.scala
@@ -1,0 +1,50 @@
+package org.podval.tools.test.nested
+
+import org.podval.tools.build.{ScalaBackend, ScalaPlatform, ScalaVersion}
+import org.podval.tools.test.testproject.{Feature, Fixture, GroupingFunSpec}
+
+class NestedSuitesTest extends GroupingFunSpec:
+  groupTest(
+    features = NestedSuitesTest.features,
+    fixtures = NestedSuitesTest.fixtures,
+    platforms = NestedSuitesTest.platforms
+  )
+
+  groupTest(
+    features = NestedSuitesTest.features,
+    fixtures = NestedSuitesTest.fixtures,
+    platforms = NestedSuitesTest.platforms,
+    combinedFixtureNameOpt = Some("combined frameworks")
+  )
+
+object NestedSuitesTest:
+  val nestedSuites: Feature = Feature(
+    name = "nested suites"
+  )
+  
+  val features: List[Feature] = List(
+    nestedSuites,
+  )
+
+  val fixtures: List[Fixture] = List(
+//    JUnit4Fixture,
+//    JUnit4ScalaJSFixture,
+//    JUnit5Fixture,
+//    MUnitFixture,
+//    ScalaCheckFixture,
+    ScalaTestFixture,
+//    Spec2Fixture,
+//    UTestFixture,
+//    ZioTestFixture
+  )
+
+  val platforms: Seq[ScalaPlatform] = Seq(
+    ScalaPlatform(ScalaVersion.Scala3         .versionDefault, ScalaBackend.Jvm),
+    ScalaPlatform(ScalaVersion.Scala3         .versionDefault, ScalaBackend.JS ()),
+
+    ScalaPlatform(ScalaVersion.Scala2.Scala213.versionDefault, ScalaBackend.Jvm),
+    ScalaPlatform(ScalaVersion.Scala2.Scala213.versionDefault, ScalaBackend.JS ()),
+
+    ScalaPlatform(ScalaVersion.Scala2.Scala212.versionDefault, ScalaBackend.Jvm),
+    ScalaPlatform(ScalaVersion.Scala2.Scala212.versionDefault, ScalaBackend.JS ()),
+  )

--- a/src/test/scala/org/podval/tools/test/nested/ScalaTestFixture.scala
+++ b/src/test/scala/org/podval/tools/test/nested/ScalaTestFixture.scala
@@ -1,0 +1,44 @@
+package org.podval.tools.test.nested
+
+import org.podval.tools.test.testproject.ForClass.*
+import org.podval.tools.test.testproject.{Feature, Fixture, ForClass, SourceFile}
+
+object ScalaTestFixture extends Fixture(
+  framework = org.podval.tools.test.framework.ScalaTest,
+  includeTestNames = Seq("org.podval.tools.test.ScalaTestNesting"),
+  testSources = Seq(
+    SourceFile("ScalaTestNested",
+      s"""import org.scalatest.flatspec.AnyFlatSpec
+         |import org.scalatest.matchers.should.Matchers
+         |
+         |final class ScalaTestNested extends AnyFlatSpec with Matchers {
+         |  "success" should "pass" in {}
+         |  "failure" should "fail" in { 2 * 2 shouldBe 5 }
+         |}
+         |""".stripMargin
+    ),
+    SourceFile("ScalaTestNesting",
+      s"""import org.scalatest.Suites
+         |
+         |class ScalaTestNesting extends Suites(
+         |  new ScalaTestNested
+         |)
+         |""".stripMargin
+    )
+  )
+):
+  override def checks(feature: Feature): Seq[ForClass] = feature match
+    case NestedSuitesTest.nestedSuites =>
+      Seq(
+        forClass("ScalaTestNesting",
+          passed("success should pass"),
+          testCount(2),
+          failedCount(1)
+        ),
+        forClass("ScalaTestNested",
+          absentClass
+        )
+      )
+
+
+

--- a/src/test/scala/org/podval/tools/test/testproject/Feature.scala
+++ b/src/test/scala/org/podval/tools/test/testproject/Feature.scala
@@ -3,9 +3,6 @@ package org.podval.tools.test.testproject
 final class Feature(
   val name: String,
   val maxParallelForks: Int = 1, // values greater than 1 are ignored on Scala.js
-  val includeTestNames: Seq[String] = Seq.empty,
-  val excludeTestNames: Seq[String] = Seq.empty,
-  val commandLineIncludeTestNames: Seq[String] = Seq.empty,
   val includeTags: Seq[String] = Seq.empty,
   val excludeTags: Seq[String] = Seq.empty
 ) derives CanEqual:

--- a/src/test/scala/org/podval/tools/test/testproject/Fixture.scala
+++ b/src/test/scala/org/podval/tools/test/testproject/Fixture.scala
@@ -6,6 +6,9 @@ abstract class Fixture(
   val framework: FrameworkDescriptor,
   val mainSources: Seq[SourceFile] = Seq.empty,
   val testSources: Seq[SourceFile],
+  val includeTestNames: Seq[String] = Seq.empty,
+  val excludeTestNames: Seq[String] = Seq.empty,
+  val commandLineIncludeTestNames: Seq[String] = Seq.empty,
   val runOutputExpectations: Seq[String] = Seq.empty
 ):
   def checks(feature: Feature): Seq[ForClass]

--- a/src/test/scala/org/podval/tools/test/testproject/GroupingFunSpec.scala
+++ b/src/test/scala/org/podval/tools/test/testproject/GroupingFunSpec.scala
@@ -113,8 +113,8 @@ class GroupingFunSpec extends AnyFunSpec:
       mainSources = fixtures.flatMap(_.mainSources),
       testSources = fixtures.flatMap(_.testSources),
       frameworks = fixtures.map(_.framework),
-      includeTestNames = feature.includeTestNames,
-      excludeTestNames = feature.excludeTestNames,
+      includeTestNames = fixtures.flatMap(_.includeTestNames),
+      excludeTestNames = fixtures.flatMap(_.excludeTestNames),
       includeTags = feature.includeTags,
       excludeTags = feature.excludeTags,
       maxParallelForks = feature.maxParallelForks,
@@ -124,7 +124,7 @@ class GroupingFunSpec extends AnyFunSpec:
     test(
       project,
       checks = fixtures.flatMap(_.checks(feature)),
-      commandLineIncludeTestNames = feature.commandLineIncludeTestNames
+      commandLineIncludeTestNames = fixtures.flatMap(_.commandLineIncludeTestNames)
     )
 
     if !manyFixtures then


### PR DESCRIPTION
- do not set `explicitlySpecified` to `true` even if the class matches the filter;
- adjust `TestFilterTest` accordingly;
- moved filter from `Feature` to `Fixture`;
- added `NestedSuitesTest`;
- added `ScalaTestFixture` to it;

fixes #32