### PR TITLE
Nested suites test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-03-31
+- fix: running test cases of the nested test suites on ScalaTest;
+- fix: attribute test cases to the correct test classes;
+- test: added `NestedSuitesTest` for testing of the nested test suite support;
+- doc: Nested Test Suites, Credits, etc.
+- cleanup: `RunTestClassProcessor`;
+- dependency updates;
+- WIP: mixing JVM and Scala.js;
+
 ## [0.6.0] - 2025-03-25
 - fix: remaining Scala 2.12 incompatibilities;
 - feat: classfile-based test detection (including JUnit4 for Scala.js);

--- a/README.adoc
+++ b/README.adoc
@@ -1171,7 +1171,7 @@ Scala 2.13 library is on the classpath, even if the project uses Scala 2.12...
 
 I'd rather uglify my code a little than fight with classpath though ;)
 
-=== Tags
+=== Test Tagging
 Although it is tempting to help the test frameworks out by
 filtering tests based on their tags
 returned by the test framework in `task.tags`, it is:

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 :toc: preamble
 // INCLUDED ATTRIBUTES
 :version-gradle: 8.13
-:version-plugin: 0.6.0
+:version-plugin: 0.6.1
 :version-scala: 3.6.4
 :version-scala2-minor: 2.13
 :version-scala2: 2.13.16
@@ -35,6 +35,10 @@ This is a `Gradle` plugin that supports:
 - compiling, linking and running `Scala.js` code;
 - testing it using `sbt`-compatible testing frameworks;
 - testing plain Scala code (without Scala.js) using `sbt`-compatible testing frameworks.
+
+Currently, plugin does NOT support Gradle projects that
+contain both JVM and Scala.js code;
+this is https://github.com/dubinsky/scalajs-gradle/issues/4[in the works].
 
 If needed, plugin automatically:
 
@@ -78,8 +82,8 @@ which uses
 https://github.com/scala-js/scala-js/tree/main/sbt-plugin/src/main/scala/org/scalajs/sbtplugin[Scala.js sbt plugin];
 I want to be able to use my preferred build tool - https://gradle.org[Gradle].
 
-Existing Scala.js Gradle https://github.com/gtache/scalajs-gradle[plugin] by
-https://github.com/gtache[gtache] seems to be no longer maintained.
+Existing Scala.js Gradle https://github.com/gtache/scalajs-gradle[plugin]
+seems to be no longer maintained.
 
 Hence, this plugin.
 
@@ -92,9 +96,9 @@ Multiple test frameworks can be used in the same project at the same time
 but sbt does it, so I must too ;)).
 
 For years, I used https://github.com/maiflai/gradle-scalatest[Gradle ScalaTest plugin]
-to run my Scala Tests; thank you, https://github.com/maiflai[maiflai]!
+to run my Scala Tests.
 Since my plugin integrates with Gradle - and through it, with IntelliJ Idea -
-some of the issues that maiflai's plugin has my does not:
+some of the issues that that plugin has my does not:
 https://github.com/maiflai/gradle-scalatest/issues/67[Test events were not received],
 https://github.com/maiflai/gradle-scalatest/issues/69[ASCII Control Characters Printed].
 
@@ -479,18 +483,23 @@ node {
 If Node.js version is not specified, plugin uses "ambient" Node.js -
 the one installed on the machine where it is running.
 
-If Node.js version is specified, plugin will install it (under `~/.gradle/nodejs`) and use it.
+TODO install default version if there is no ambient one.
 
-Scala.js does not support versions of Node.js newer than "{version-node}", so none of the "17.9.1", "18.15.0", "19.8.1".
-I do not know anything about Node.js, and find this surprising - but I am sure there is a good
-technical or political reason for this ;)
+If Node.js version is specified, plugin will install it
+(under `~/.gradle/nodejs`) and use it.
+
+Scala.js does not support versions of Node.js newer than "{version-node}",
+so none of the "17.9.1", "18.15.0", "19.8.1".
+I do not know anything about Node.js, and find this surprising -
+but I am sure there is a good technical or political reason for this ;)
 
 If no Node modules to install are listed, plugin installs the `jsdom` module,
 which is required for `org.scala-js:scalajs-env-jsdom-nodejs`.
 
 To get better traces, one can add `source-map-support` module.
 
-Node modules for the project are installed in the `node_modules` directory in the project root.
+Node modules for the project are installed in the `node_modules`
+directory in the project root.
 
 If `package.json` file does not exist, plugin runs `npm init private`.
 
@@ -818,6 +827,90 @@ During a dry run, though, I want to see _everything_ that was skipped,
 including test classes that were skipped entirely;
 for such, a test case named `dry run` is reported as skipped.
 
+=== Nested Test Suites
+
+Some test frameworks have a notion of _nested test suites_,
+where nesting test class aggregates nested test classes.
+
+Plugin supports such scenario and attributes test cases from the nested
+suites to them:
+test report will have no test cases for the nesting class;
+instead, test cases will be reported for the nested classes they belong to.
+
+==== JUnit4
+
+JUnit4 uses an annotation on the nesting suite to indicate that it
+contains nested suites:
+
+[source,scala]
+----
+@org.junit.runner.RunWith(classOf[org.junit.runners.Suite])
+----
+
+and another annotation that lists the nested suites:
+
+[source,scala]
+----
+@org.junit.runners.Suite.SuiteClasses(Array(
+  classOf[JUnit4Nested]
+))
+----
+
+For example, `JUnit4Nesting` contains `JUnit4Nested`:
+
+[source,scala]
+----
+@org.junit.runner.RunWith(classOf[org.junit.runners.Suite])
+@org.junit.runners.Suite.SuiteClasses(Array(
+  classOf[JUnit4Nested]
+))
+class JUnit4Nesting {
+}
+
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+final class JUnit4Nested {
+  @Test def success(): Unit = assertTrue("should be true", true)
+  @Test def failure(): Unit = assertTrue("should be true", false)
+}
+----
+
+By default, `JUnit4` 's `sbt` framework
+https://github.com/sbt/junit-interface/blob/develop/src/main/java/com/novocode/junit/JUnitRunner.java#L39[ignores] the
+`org.junit.runners.Suite` runner; plugin supplies an appropriate
+arguments to `JUnit4` to enable it.
+
+==== JUnit4 for Scala.js
+Since annotations are not available at runtime on Scala.js,
+`JUnit4 for Scala.js` does not support nested test suites.
+
+==== ScalaTest
+In `ScalaTest`, nesting of the test suites is indicated by
+ceriving the nesting class from `org.scalatest.Suites`
+and listing the nested suites in its constructor:
+
+[source,scala]
+----
+class ScalaTestNesting extends org.scalatest.Suites(
+  new ScalaTestNested
+)
+----
+
+==== Other Test Frameworks
+
+As far as I can tell, there is no support for nesting test classes in:
+
+- MUnit
+- ScalaCheck
+- Specs2
+- UTest
+- ZIO Test
+
+TODO Some of them do provide means of structuring the tests hierarchically within one class,
+and this should be tested with the plugin and documented.
+
+
 [#intellij-idea-integration]
 == IntelliJ Idea Integration
 
@@ -900,31 +993,22 @@ so that icon runs the whole class, not the test method it is for.
 
 For `specs2` and `uTest`, there are no gutter icons for individual test methods.
 
-== Notes and Credits
+== Implementation Notes
 
 === Scala.js Linking
 It is reasonably easy - if repetitive - to configure the Scala compiler and add needed Scala.js dependencies by hand;
 what really pushed me to build this plugin is the difficulty and ugliness involved in
 manually setting up Scala.js linking in a Gradle build script.
 
-A Stack Overflow https://stackoverflow.com/a/65777102/670095[answer]
-by https://stackoverflow.com/users/1149944/gzm0[gzm0] was _extremely_ helpful
-for understanding how the Scala.js linker should be called. Thanks!
-
-I also looked at
+I perused the code of:
 
 - https://www.scala-js.org/doc/tutorial/basic[Scala.js Tutorial]
 - https://github.com/scala-js/scala-js/tree/main/linker-interface[Scala.js Linker]
 - https://github.com/scala-js/scala-js/tree/main/sbt-plugin/src/main/scala/org/scalajs/sbtplugin[Scala.js sbt plugin]
 - https://github.com/gtache/scalajs-gradle[Old Scala.js Gradle plugin] by https://github.com/gtache[gtache]
 - https://github.com/scala-js/scala-js-cli/tree/main/src/main/scala/org/scalajs/cli[Scala.js CLI]
-- https://www.scala-lang.org/2020/11/03/scalajs-for-scala-3.html[Implementing Scala.JS Support for Scala 3]
 
 === Testing
-
-Basic testing functionality was
-https://github.com/dubinsky/scalajs-gradle/issues/7[requested]
-by https://github.com/zstone1[zstone1] - thanks for the encouragement!
 
 To figure out how `sbt` itself integrates with testing frameworks, I had to untangle some `sbt` code, including:
 
@@ -989,8 +1073,7 @@ so just wrap what remains in `TestExecutionException`.
 
 `Node.js` support that the plugin provides
 is heavily inspired by (read: copied and reworked from :))
-https://github.com/srs/gradle-node-plugin[gradle-node-plugin]
-by https://github.com/srs[srs].
+https://github.com/srs/gradle-node-plugin[gradle-node-plugin].
 
 That plugin is not used directly because its tasks are not reusable
 unless the plugin is applied to the project,
@@ -1048,16 +1131,19 @@ This is _probably_ the reason why Gradle:
 - makes all test ids `CompositeIdGenerator.CompositeId`
 - registers a `Serializer[CompositeIdGenerator.CompositeId]` in `TestEventSerializer`.
 
-Gradle just wants to attract attention to its `TestEventSerializer`, so it registers
-serializers for the types of the first parameters of all methods - including the test ids ;)
+Gradle just wants to attract attention to its `TestEventSerializer`,
+so it registers serializers for the types
+of the first parameters of all methods - including the test ids ;)
 
-And since the minimum of composed is two, Gradle uses test ids that are composite of two Longs.
+And since the minimum of composed is two,
+Gradle uses test ids that are composite of two Longs.
 
 AbstractTestTask installs `StateTrackingTestResultProcessor`
 which keeps track of all tests that are executing in any `TestWorker`.
 That means that test ids must be scoped per `TestWorker`.
 Each `TestWorker` has an `idGenerator` which it uses to generate `WorkerTestClassProcessor.workerSuiteId`;
-that same `idGenerator` can be used to generate sequential ids for the tests in the worker,
+that same `idGenerator` can be used to generate sequential ids
+for the tests in the worker,
 satisfying the uniqueness requirements - and resulting in the test ids always being
 a composite of exactly two Longs!
 
@@ -1117,8 +1203,6 @@ This allows the plugin to add dependencies
 with correct versions and built for correct version of Scala
 which may be different from the one
 plugin uses, so that Scala 2.12 can be supported.
-Support for Scala 2.12 was https://github.com/dubinsky/scalajs-gradle/issues/9[requested]
-by https://github.com/machaval[machaval] - thanks for the encouragement!
 
 Classpath expansion allows the plugin to use classes from dependencies
 that are added dynamically, but since they become available only after
@@ -1181,36 +1265,6 @@ that support tagging accept
 arguments that allow them to do the filtering internally;
 - destructive, since none of the test frameworks plugin supports
 populate `task.tags`, so with explicit tag inclusions, none of the tests run!
-
-=== Nested Tasks
-`ScalaCheck` processes test _methods_ as nested tasks (with `TestSelector`);
-other frameworks just run them and report the results via event handler.
-
-`uTest` uses `NestedTestSelector` for this, while others use `TestSelector`.
-
-`ScalaTest` does not return nested tasks for nested suites
-(or anything, according to the documentation of its Runner);
-events for the tests in the nested suites have `NestedTestSelector`.
-
-=== JUnit4 Test Names
-`JUnit4` - and thus `MUnit` which is based on it - set both the event's
-`fullyQualifiedName` and the `selector` to something like <class name>.<method name>;
-method names like this just look stupid,
-but class names look like new classes to Gradle (since the event fingerprint says so),
-which corrupts test reports.
-I had to work around this.
-
-=== JUnit4 for Scala.js Throwable
-It is possible, albeit not nice, for the test framework to not populate
-the `event.throwable` of the `Failure` event;
-`JUnit4 for Scala.js` used to do this (see https://github.com/scala-js/scala-js/pull/5132).
-
-Gradle treats a test as failed only when it receives a `throwable` for the test -
-otherwise, although XML report does record the failure, HTML report does not,
-nor does Gradle build fail.
-
-This is why I supply a synthesized event for _method_ failures
-if one did not come up from the framework.
 
 [#junit4-scalajs-scala-2]
 === JUnit4 for Scala.js and Scala 2
@@ -1291,6 +1345,40 @@ Presence of a bootstrapper `TestClass$scalajs$junit$bootstrapper$`
 is treated as a presence of the `@Test` annotation on `TestClass`,
 which marks it as a test belonging to the `JUnit4 for Scala.js` test framework.
 
+=== Nested Tasks and Test Cases
+
+``sbt` test interface allows test framework to return nested tasks
+when executing a task;
+of the test frameworks supported by the plugin,
+only `ScalaCheck` uses this mechanism:
+it returns test cases of the test class being executed
+as  nested tasks (with `TestSelector`).
+
+All other frameworks run the test cases directly
+and report the results via event handler;
+what selector is reported depends on the test framework:
+
+- most test frameworks use `TestSelector`;
+- `uTest` uses `NestedTestSelector`;
+- `ScalaTest` uses `NestedTestSelector` for test cases from the nested suites;
+- `JUnit4`, `JUnit4 for Scala.js` and `MUnit` use `TestSelector`
+even for test cases from the nested suites,
+but they prepend the name of the class to the test case name
+(both in the selector and in the event's `fullyQualifiedName`);
+plugin makes sure to attribute test cases to the correct test classes.
+
+=== JUnit4 for Scala.js Throwable
+It is possible, albeit not nice, for the test framework to not populate
+the `event.throwable` of the `Failure` event;
+`JUnit4 for Scala.js` used to do this (see https://github.com/scala-js/scala-js/pull/5132).
+
+Gradle treats a test as failed only when it receives a `throwable` for the test -
+otherwise, although XML report does record the failure, HTML report does not,
+nor does Gradle build fail.
+
+This is why I supply a synthesized event for _method_ failures
+if one did not come up from the framework.
+
 === Gradle Internals
 To stop tests from being forked - which is needed to run tests on Scala.js -
 I had to fork `org.gradle.api.internal.tasks.testing.detection.DefaultTestExecuter`
@@ -1323,10 +1411,62 @@ which recognizes only the test frameworks explicitly supported by Gradle (`JUnit
 
 === AsciiDoc
 GitHub stupidly disables AsciDoc includes in README;
-see https://github.com/github/markup/issues/1095.
+see https://github.com/github/markup/issues/1095[the discussion].
 
 One include (of the `versions.adoc` in `README.adoc`.)
 is not enough to bother with https://github.com/asciidoctor/asciidoctor-reducer[AsciiDoctor Reducer],
 so I just patch the Readme.adoc...
 
 I also write versions to `gradle.properties` and use them in `gradle.build`.
+
+== Credits
+
+I want to thank the maintainers of:
+
+- https://www.scala-js.org/[Scala.js];
+- https://github.com/sbt/test-interface[sbt test interface];
+- https://github.com/junit-team/junit4[JUnit4];
+- sbt test framework https://github.com/sbt/junit-interface[implementation] for JUnit4;
+- https://scalameta.org/munit[MUnit];
+- https://scalacheck.org[ScalaCheck];
+- https://www.scalatest.org[ScalaTest];
+- https://etorreborre.github.io/specs2[specs2];
+- https://github.com/com-lihaoyi/utest[uTest];
+- https://github.com/zio/zio[ZIO Test];
+
+I want to thank:
+
+- https://github.com/maiflai[maiflai] for the
+https://github.com/maiflai/gradle-scalatest[ScalaTest Gradle plugin];
+- https://github.com/gtache[gtache] for the
+https://github.com/gtache/scalajs-gradle[existing Scala.js Gradle plugin];
+- https://github.com/srs[srs] for the
+https://github.com/srs/gradle-node-plugin[Node.js Gradle Plugin];
+- https://stackoverflow.com/users/1149944/gzm0[gzm0] for the
+Stack Overflow https://stackoverflow.com/a/65777102/670095[answer]
+that was _extremely_ helpful
+for understanding how the Scala.js linker should be called;
+- https://github.com/zstone1[zstone1] for the encouragement and for
+https://github.com/dubinsky/scalajs-gradle/issues/7[requesting]
+basic testing functionality;
+- https://github.com/machaval[machaval] for the encouragement, for
+https://github.com/dubinsky/scalajs-gradle/issues/9[requesting]
+support for Scala 2.12
+and for helping me understand the https://github.com/dubinsky/scalajs-gradle/issues/16[limits]
+of such support;
+- https://github.com/qwqawawow[qwqawawow] for a
+https://github.com/dubinsky/scalajs-gradle/issues/18[bug report];
+- https://github.com/a01fe[a01fe] for a
+https://github.com/dubinsky/scalajs-gradle/issues/34[bug report];
+- https://github.com/kyri-petrou[kyri-petrou] for accepting my fix
+to a ZIO Test https://github.com/zio/zio/pull/9680[issue]
+with the treatment of test wildcards;
+- https://github.com/sjrd[sjrd] for the helpful text
+https://www.scala-lang.org/2020/11/03/scalajs-for-scala-3.html[Implementing Scala.JS Support for Scala 3]
+and for working with me on fixing issues
+with JUnit4 for Scala.js reporting of
+https://github.com/scala-js/scala-js/pull/5132[test failure throwable]
+and https://github.com/scala-js/scala-js/pull/5134[test duration];
+- https://github.com/cheeseng[cheeseng] for helping me understand
+the https://github.com/scalatest/scalatest/issues/2357[problem]
+with running nested ScalaTest suites using my plugin;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.podval.tools.scalajs.disabled = true
 version_gradle = 8.13
-version_plugin = 0.6.0
+version_plugin = 0.6.1
 version_scala = 3.6.4
 version_scala2_minor = 2.13
 version_scala2 = 2.13.16

--- a/pre-existing-configurations.txt
+++ b/pre-existing-configurations.txt
@@ -1,0 +1,186 @@
+> Task :scalajs-gradle:compileJava NO-SOURCE
+
+> Task :scalajs-gradle:compileScala
+[Warn] /home/dub/Projects/scalajs/scalajs-gradle/src/main/scala/org/podval/tools/scalajsplugin/BackendDelegate.scala:116:40: [33mclass[0m [35mDefaultScalaSourceSet[0m in [33mpackage[0m [35morg.gradle.api.internal.tasks[0m is deprecated: see corresponding Javadoc for more information.
+[Warn] /home/dub/Projects/scalajs/scalajs-gradle/src/main/scala/org/podval/tools/scalajsplugin/BackendDelegate.scala:117:45: [33mclass[0m [35mDefaultScalaSourceSet[0m in [33mpackage[0m [35morg.gradle.api.internal.tasks[0m is deprecated: see corresponding Javadoc for more information.
+[Warn] /home/dub/Projects/scalajs/scalajs-gradle/src/main/scala/org/podval/tools/scalajsplugin/BackendDelegate.scala:122:28: [33mmethod[0m [35mgetConvention[0m in [33mclass[0m [35mDslObject[0m is deprecated: see corresponding Javadoc for more information.
+three warnings found
+
+> Task :scalajs-gradle:pluginDescriptors UP-TO-DATE
+> Task :scalajs-gradle:processResources UP-TO-DATE
+> Task :scalajs-gradle:classes
+> Task :scalajs-gradle:jar
+
+> Task :resolvableConfigurations
+--------------------------------------------------
+Configuration annotationProcessor
+--------------------------------------------------
+Annotation processors and their dependencies for source set 'main'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+
+--------------------------------------------------
+Configuration compileClasspath
+--------------------------------------------------
+Compile classpath for source set 'main'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.jvm.version         = 21
+    - org.gradle.libraryelements     = classes
+    - org.gradle.usage               = java-api
+Extended Configurations
+    - compileOnly
+    - implementation
+
+--------------------------------------------------
+Configuration incrementalScalaAnalysisFormain
+--------------------------------------------------
+Incremental compilation analysis files for main
+Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':incrementalScalaAnalysisFormain' and [configuration ':incrementalScalaAnalysisElements'] contain identical attribute sets. Consider adding an additional attribute to one of the configurations to disambiguate them. For more information, please refer to https://docs.gradle.org/8.13/userguide/upgrading_version_7.html#unique_attribute_sets in the Gradle documentation.
+
+Attributes
+    - org.gradle.category = scala-analysis
+    - org.gradle.usage    = incremental-analysis
+Extended Configurations
+    - implementation
+
+--------------------------------------------------
+Configuration incrementalScalaAnalysisFortest
+--------------------------------------------------
+Incremental compilation analysis files for test
+Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':incrementalScalaAnalysisFortest' and [configuration ':incrementalScalaAnalysisElements'] contain identical attribute sets. Consider adding an additional attribute to one of the configurations to disambiguate them. For more information, please refer to https://docs.gradle.org/8.13/userguide/upgrading_version_7.html#unique_attribute_sets in the Gradle documentation.
+
+Attributes
+    - org.gradle.category = scala-analysis
+    - org.gradle.usage    = incremental-analysis
+Extended Configurations
+    - testImplementation
+
+--------------------------------------------------
+Configuration runtimeClasspath
+--------------------------------------------------
+Runtime classpath of source set 'main'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.jvm.version         = 21
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+Extended Configurations
+    - implementation
+    - runtimeOnly
+
+--------------------------------------------------
+Configuration scalaCompilerPlugins
+--------------------------------------------------
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+
+--------------------------------------------------
+Configuration scalaToolchainRuntimeClasspath
+--------------------------------------------------
+Runtime classpath for the Scala toolchain
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+Extended Configurations
+    - scalaToolchain
+
+--------------------------------------------------
+Configuration testAnnotationProcessor
+--------------------------------------------------
+Annotation processors and their dependencies for source set 'test'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+
+--------------------------------------------------
+Configuration testCompileClasspath
+--------------------------------------------------
+Compile classpath for source set 'test'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.jvm.version         = 21
+    - org.gradle.libraryelements     = classes
+    - org.gradle.usage               = java-api
+Extended Configurations
+    - testCompileOnly
+    - testImplementation
+
+--------------------------------------------------
+Configuration testRuntimeClasspath
+--------------------------------------------------
+Runtime classpath of source set 'test'.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.environment     = standard-jvm
+    - org.gradle.jvm.version         = 21
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+Extended Configurations
+    - testImplementation
+    - testRuntimeOnly
+
+--------------------------------------------------
+Configuration zinc
+--------------------------------------------------
+The Zinc incremental compiler to be used for this Scala project.
+
+--------------------------------------------------
+Compatibility Rules
+--------------------------------------------------
+The following Attributes have compatibility rules defined.
+
+    - org.gradle.dependency.bundling
+    - org.gradle.jvm.environment
+    - org.gradle.jvm.version
+    - org.gradle.libraryelements
+    - org.gradle.plugin.api-version
+    - org.gradle.usage
+
+--------------------------------------------------
+Disambiguation Rules
+--------------------------------------------------
+The following Attributes have disambiguation rules defined.
+
+    - org.gradle.category (1)
+    - org.gradle.dependency.bundling (5)
+    - org.gradle.jvm.environment (6)
+    - org.gradle.jvm.version (3)
+    - org.gradle.libraryelements (4)
+    - org.gradle.plugin.api-version
+    - org.gradle.usage (2)
+
+(#): Attribute disambiguation precedence
+
+
+BUILD SUCCESSFUL in 2s
+5 actionable tasks: 3 executed, 2 up-to-date

--- a/src/main/scala/org/podval/tools/build/Gradle.scala
+++ b/src/main/scala/org/podval/tools/build/Gradle.scala
@@ -1,49 +1,22 @@
 package org.podval.tools.build
 
-import org.gradle.api.{Project, Task}
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.{SourceSet, SourceSetContainer, TaskProvider}
-import org.gradle.api.tasks.scala.ScalaCompile
-import scala.jdk.CollectionConverters.SetHasAsScala
+import org.gradle.api.tasks.SourceSet
 
-// TODO move everything into BackendDelegate and dissolve.
 object Gradle:
   def getConfiguration(project: Project, name: String): Configuration = project
     .getConfigurations
     .getByName(name)
-
-  def createConfiguration(project: Project, name: String, description: String): Configuration =
-    val result: Configuration = project.getConfigurations.create(name)
-    result.setVisible(false)
-    result.setCanBeConsumed(false)
-    result.setDescription(description)
-    result
-
-  def getSourceSets(project: Project): SourceSetContainer = project
+  
+  def getSourceSet(project: Project, name: String): SourceSet = project
     .getExtensions
     .getByType(classOf[JavaPluginExtension])
     .getSourceSets
-
-  def getSourceSet(project: Project, name: String): SourceSet = getSourceSets(project).getByName(name)
-
-  def getClassesTask(project: Project, sourceSet: SourceSet): Task = project
-    .getTasks
-    .getByName(sourceSet.getClassesTaskName)
+    .getByName(name)
   
-  def getClassesTask(project: Project, sourceSetName: String): Task = project
-    .getTasks
-    .getByName(getSourceSet(project, sourceSetName).getClassesTaskName)
-  
-  def getScalaCompile(project: Project, sourceSetName: String): ScalaCompile = getClassesTask(project, sourceSetName)
-    .getDependsOn
-    .asScala
-    .find(classOf[TaskProvider[ScalaCompile]].isInstance)
-    .get
-    .asInstanceOf[TaskProvider[ScalaCompile]]
-    .get
-
   def toOption[T](property: Property[T]): Option[T] =
     if !property.isPresent then None else Some(property.get)
     

--- a/src/main/scala/org/podval/tools/build/Gradle.scala
+++ b/src/main/scala/org/podval/tools/build/Gradle.scala
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.{SourceSet, SourceSetContainer, TaskProvider}
 import org.gradle.api.tasks.scala.ScalaCompile
 import scala.jdk.CollectionConverters.SetHasAsScala
 
+// TODO move everything into BackendDelegate and dissolve.
 object Gradle:
   def getConfiguration(project: Project, name: String): Configuration = project
     .getConfigurations
@@ -26,6 +27,10 @@ object Gradle:
     .getSourceSets
 
   def getSourceSet(project: Project, name: String): SourceSet = getSourceSets(project).getByName(name)
+
+  def getClassesTask(project: Project, sourceSet: SourceSet): Task = project
+    .getTasks
+    .getByName(sourceSet.getClassesTaskName)
   
   def getClassesTask(project: Project, sourceSetName: String): Task = project
     .getTasks

--- a/src/main/scala/org/podval/tools/scalajsplugin/BackendDelegate.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/BackendDelegate.scala
@@ -257,3 +257,27 @@ abstract class BackendDelegate(
         s"$sourceRoot/$path/${sourceDirectorySet.getName}/${sourceSet.getName}"
       )
     )
+
+  protected final def createConfiguration(name: String, description: String): Configuration =
+    val result: Configuration = project.getConfigurations.create(name)
+    result.setVisible(false)
+    result.setCanBeConsumed(false)
+    result.setDescription(description)
+    result
+    
+  protected final def getClassesTask(sourceSet: SourceSet): Task = project
+    .getTasks
+    .getByName(sourceSet.getClassesTaskName)
+  
+  protected final def getClassesTask(sourceSetName: String): Task = project
+    .getTasks
+    .getByName(Gradle.getSourceSet(project, sourceSetName).getClassesTaskName)
+  
+  protected final def getScalaCompile(sourceSetName: String): ScalaCompile = getClassesTask(sourceSetName)
+    .getDependsOn
+    .asScala
+    .find(classOf[TaskProvider[ScalaCompile]].isInstance)
+    .get
+    .asInstanceOf[TaskProvider[ScalaCompile]]
+    .get
+  

--- a/src/main/scala/org/podval/tools/scalajsplugin/ScalaJSPlugin.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/ScalaJSPlugin.scala
@@ -12,6 +12,8 @@ import scala.jdk.CollectionConverters.IterableHasAsScala
 import java.io.File
 import javax.inject.Inject
 
+// TODO use TaskProviders for all created tasks:
+// use register() instead of create() and move task configuration into actions.
 final class ScalaJSPlugin @Inject(
   objectFactory: ObjectFactory
 ) extends Plugin[Project]:

--- a/src/main/scala/org/podval/tools/scalajsplugin/VersionsWriter.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/VersionsWriter.scala
@@ -13,7 +13,7 @@ import java.io.File
 object VersionsWriter:
   private val versions: Seq[(String, Any)] = Seq(
     "gradle" -> "8.13",
-    "plugin" -> "0.6.0",
+    "plugin" -> "0.6.1",
     
     "scala" -> ScalaVersion.Scala3.versionDefault,
     "scala2-minor" -> ScalaVersion.Scala2.majorAndMinor,

--- a/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
@@ -1,6 +1,6 @@
 package org.podval.tools.scalajsplugin.jvm
 
-import org.gradle.api.Project
+import org.gradle.api.{Project, Task}
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
@@ -25,11 +25,19 @@ final class JvmDelegate(
 
   override def configurationToAddToClassPath: Option[String] = None
 
+  override def configureProject(isScala3: Boolean): Unit = ()
+
   override def setUpProject(): Unit =
     project.getTasks.replace("test", classOf[JvmTestTask])
 
     if isMixed then configureSourceSetDefaults(isCreate = false)
-  
+
+  override def configureTask(task: Task): Unit = task match
+    case testTask: JvmTestTask =>
+      testTask.getDependsOn.add(getClassesTask(testSourceSetName))
+
+    case _ =>
+
   override def dependencyRequirements(
     pluginScalaPlatform: ScalaPlatform,
     projectScalaPlatform: ScalaPlatform
@@ -44,11 +52,6 @@ final class JvmDelegate(
     )
   )
 
-  override def configureProject(projectScalaPlatform: ScalaPlatform): Unit =
-    project.getTasks.asScala.foreach:
-      case testTask: JvmTestTask =>
-        testTask.getDependsOn.add(getClassesTask(testSourceSetName))
-      case _ =>
 
 object JvmDelegate:
   final val sourceRoot: String = "jvm"

--- a/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
@@ -47,7 +47,7 @@ final class JvmDelegate(
   override def configureProject(projectScalaPlatform: ScalaPlatform): Unit =
     project.getTasks.asScala.foreach:
       case testTask: JvmTestTask =>
-        testTask.getDependsOn.add(Gradle.getClassesTask(project, testSourceSetName))
+        testTask.getDependsOn.add(getClassesTask(testSourceSetName))
       case _ =>
 
 object JvmDelegate:

--- a/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/jvm/JvmDelegate.scala
@@ -3,9 +3,11 @@ package org.podval.tools.scalajsplugin.jvm
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
-import org.podval.tools.build.{DependencyRequirement, ScalaPlatform}
+import org.gradle.api.tasks.SourceSet
+import org.podval.tools.build.{DependencyRequirement, Gradle, ScalaPlatform}
 import org.podval.tools.scalajsplugin.BackendDelegate
 import org.podval.tools.test.SbtTestInterface
+import scala.jdk.CollectionConverters.IterableHasAsScala
 
 final class JvmDelegate(
   project: Project,
@@ -17,15 +19,17 @@ final class JvmDelegate(
 ):
   override def sourceRoot: String = JvmDelegate.sourceRoot
 
+  override def mainSourceSetName: String = SourceSet.MAIN_SOURCE_SET_NAME
+
+  override def testSourceSetName: String = SourceSet.TEST_SOURCE_SET_NAME
+
+  override def configurationToAddToClassPath: Option[String] = None
+
   override def setUpProject(): Unit =
     project.getTasks.replace("test", classOf[JvmTestTask])
 
     if isMixed then configureSourceSetDefaults(isCreate = false)
-
-  override def configurationToAddToClassPath: Option[String] = None
-
-  override def configureProject(projectScalaPlatform: ScalaPlatform): Unit = ()
-
+  
   override def dependencyRequirements(
     pluginScalaPlatform: ScalaPlatform,
     projectScalaPlatform: ScalaPlatform
@@ -39,6 +43,12 @@ final class JvmDelegate(
       configurationName = JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
     )
   )
+
+  override def configureProject(projectScalaPlatform: ScalaPlatform): Unit =
+    project.getTasks.asScala.foreach:
+      case testTask: JvmTestTask =>
+        testTask.getDependsOn.add(Gradle.getClassesTask(project, testSourceSetName))
+      case _ =>
 
 object JvmDelegate:
   final val sourceRoot: String = "jvm"

--- a/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkMainTask.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkMainTask.scala
@@ -1,15 +1,11 @@
 package org.podval.tools.scalajsplugin.scalajs
 
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.tasks.{Nested, SourceSet}
+import org.gradle.api.tasks.Nested
 import org.podval.tools.scalajs.ModuleInitializer
 import scala.jdk.CollectionConverters.SetHasAsScala
 
-abstract class ScalaJSLinkMainTask extends ScalaJSLinkTask:
-  final override protected def flavour: String = "Link"
-
-  final override def sourceSetName: String = SourceSet.MAIN_SOURCE_SET_NAME
-
+abstract class ScalaJSLinkMainTask extends ScalaJSLinkTask("Link"):
   @Nested def getModuleInitializers: NamedDomainObjectContainer[ModuleInitializerProperties]
 
   final override def moduleInitializers: Option[Seq[ModuleInitializer]] =

--- a/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkTask.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkTask.scala
@@ -4,19 +4,17 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.{Input, InputFiles, Optional, OutputDirectory, OutputFile, TaskAction}
 import org.gradle.api.DefaultTask
-import org.podval.tools.build.Gradle
 import org.podval.tools.scalajs.{ModuleInitializer, ModuleKind, ModuleSplitStyle, Optimization, ScalaJSLink}
 import org.podval.tools.util.Files
 import java.io.File
 import scala.jdk.CollectionConverters.SetHasAsScala
 
-abstract class ScalaJSLinkTask extends DefaultTask with ScalaJSTask:
+abstract class ScalaJSLinkTask(
+  final override protected val flavour: String
+) extends DefaultTask with ScalaJSTask:
   setGroup("build")
   setDescription(s"$flavour ScalaJS${optimization.description}")
-  getDependsOn.add(Gradle.getClassesTask(getProject, sourceSetName))
-
-  def sourceSetName: String
-
+  
   @TaskAction final def execute(): Unit = ScalaJSLink(scalaJSCommon).link(
     reportTextFile = linkTask.getReportTextFile,
     optimization = optimization,

--- a/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkTestTask.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSLinkTestTask.scala
@@ -1,11 +1,6 @@
 package org.podval.tools.scalajsplugin.scalajs
 
-import org.gradle.api.tasks.SourceSet
 import org.podval.tools.scalajs.ModuleInitializer
 
-abstract class ScalaJSLinkTestTask extends ScalaJSLinkTask:
-  final override protected def flavour: String = "LinkTest"
-
-  final override def sourceSetName: String = SourceSet.TEST_SOURCE_SET_NAME
-
+abstract class ScalaJSLinkTestTask extends ScalaJSLinkTask("LinkTest"):
   final override def moduleInitializers: Option[Seq[ModuleInitializer]] = None

--- a/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSRunTask.scala
+++ b/src/main/scala/org/podval/tools/scalajsplugin/scalajs/ScalaJSRunTask.scala
@@ -8,6 +8,7 @@ import scala.jdk.CollectionConverters.SetHasAsScala
 trait ScalaJSRunTask extends ScalaJSTask:
   protected def linkTaskClass: Class[? <: ScalaJSLinkTask]
 
+  // TODO when switching to TaskProviders, adjust this:
   final override protected def linkTask: ScalaJSLinkTask = getDependsOn
     .asScala
     .find((candidate: AnyRef) => linkTaskClass.isAssignableFrom(candidate.getClass))

--- a/src/main/scala/org/podval/tools/test/framework/FrameworkDescriptor.scala
+++ b/src/main/scala/org/podval/tools/test/framework/FrameworkDescriptor.scala
@@ -15,6 +15,8 @@ abstract class FrameworkDescriptor(
   tagOptionStyle: OptionStyle = OptionStyle.NotSupported,
   includeTagsOption: String = "",
   excludeTagsOption: String = "",
+  additionalOptions: Array[String] = Array.empty,
+  final val includesClassNameInTestName: Boolean = false,
   final val versionDefaultScala2: Option[Version] = None,
   final val isJvmSupported: Boolean = true,
   final val isScalaJSSupported: Boolean = true,
@@ -41,11 +43,11 @@ abstract class FrameworkDescriptor(
   final def args(
     includeTags: Array[String],
     excludeTags: Array[String]
-  ): Array[String] = arrayConcat(
+  ): Array[String] = arrayConcat(additionalOptions, arrayConcat(
     tagOptionStyle.toStrings(includeTagsOption, includeTags),
-    tagOptionStyle.toStrings(excludeTagsOption, excludeTags)
-  )
-
+    tagOptionStyle.toStrings(excludeTagsOption, excludeTags),
+  ))
+  
   final def newInstance: AnyRef = Class.forName(className)
     .getDeclaredConstructor()
     .newInstance()

--- a/src/main/scala/org/podval/tools/test/framework/JUnit4.scala
+++ b/src/main/scala/org/podval/tools/test/framework/JUnit4.scala
@@ -25,6 +25,9 @@ object JUnit4 extends FrameworkDescriptor(
   tagOptionStyle = OptionStyle.ListWithEq, 
   includeTagsOption = "--include-categories", 
   excludeTagsOption = "--exclude-categories",
+  // by default, `org.junit.runners.Suite` is ignored; make sure it is not: it is needed to run nested suites:
+  additionalOptions = Array("--ignore-runners=none"),
+  includesClassNameInTestName = true,
   // This is a JVM-only test framework
   isScalaJSSupported = false,
   jvmUnderlying = Some(JUnit4Underlying)

--- a/src/main/scala/org/podval/tools/test/framework/JUnit4ScalaJS.scala
+++ b/src/main/scala/org/podval/tools/test/framework/JUnit4ScalaJS.scala
@@ -14,6 +14,7 @@ object JUnit4ScalaJS extends FrameworkDescriptor(
   versionDefault = ScalaJS.versionDefault,
   className = "com.novocode.junit.JUnitFramework",
   sharedPackages = List("com.novocode.junit", "junit.framework", "junit.extensions", "org.junit"),
+  includesClassNameInTestName = true,
   // This is a Scala.js-only test framework
   isJvmSupported = false
 ) with ScalaDependency.MakerScala2Jvm

--- a/src/main/scala/org/podval/tools/test/framework/MUnit.scala
+++ b/src/main/scala/org/podval/tools/test/framework/MUnit.scala
@@ -37,6 +37,7 @@ object MUnit extends FrameworkDescriptor(
   tagOptionStyle = OptionStyle.ListWithEq, 
   includeTagsOption = "--include-tags", 
   excludeTagsOption = "--exclude-tags",
+  includesClassNameInTestName = true,
   // on JVM, uses underlying JUni4 - via its own internal interface
   jvmUnderlying = Some(JUnit4Underlying),
   // on Scala.js, uses JUnit4 for Scala.js

--- a/src/main/scala/org/podval/tools/test/run/RunTestClassProcessor.scala
+++ b/src/main/scala/org/podval/tools/test/run/RunTestClassProcessor.scala
@@ -1,8 +1,7 @@
 package org.podval.tools.test.run
 
 import org.gradle.api.internal.tasks.testing.{DefaultTestClassDescriptor, DefaultTestMethodDescriptor,
-  DefaultTestOutputEvent, TestClassProcessor, TestClassRunInfo, TestCompleteEvent, TestDescriptorInternal,
-  TestResultProcessor, TestStartEvent}
+  DefaultTestOutputEvent, TestClassProcessor, TestClassRunInfo, TestCompleteEvent, TestResultProcessor, TestStartEvent}
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.testing.TestOutputEvent
 import org.gradle.api.tasks.testing.TestResult.ResultType
@@ -11,9 +10,12 @@ import org.gradle.internal.id.CompositeIdGenerator.CompositeId
 import org.gradle.internal.time.Clock
 import org.podval.tools.test.exception.ExceptionConverter
 import org.podval.tools.test.taskdef.{Selectors, TaskDefs, TestClassRun}
-import org.podval.tools.util.Scala212Collections.{arrayAppend, arrayFind, arrayForAll, arrayForEach, stripPrefix}
-import sbt.testing.{Event, Logger, Runner, Selector, SuiteSelector, Task, TaskDef, TestSelector}
+import org.podval.tools.util.Scala212Collections.{arrayAppend, arrayFind, arrayForAll, arrayForEach}
+import sbt.testing.{Event, Logger, Runner, Selector, Task, TaskDef, TestSelector}
 import scala.util.control.NonFatal
+
+object RunTestClassProcessor:
+  val rootTestSuiteIdPlaceholder: CompositeId = CompositeId(0L, 0L)
 
 final class RunTestClassProcessor(
   includeTags: Array[String],
@@ -36,14 +38,19 @@ final class RunTestClassProcessor(
     testId: AnyRef,
     className: String,
     selector: Selector,
+    frameworkIncludesClassNameInTestName: Boolean,
     startTime: Long
   ): Unit =
-    val testDescriptorInternal: TestDescriptorInternal = Selectors.testName(selector) match
-      case None             => DefaultTestClassDescriptor (testId, className)
-      case Some(methodName) => DefaultTestMethodDescriptor(testId, className, stripPrefix(methodName, className + "."))
-
+    val (testClassName: String, testName: Option[String]) = Selectors.testClassAndTestName(
+      className,
+      selector,
+      frameworkIncludesClassNameInTestName
+    )
+    
     testResultProcessor.started(
-      testDescriptorInternal,
+      testName match
+        case None           => DefaultTestClassDescriptor (testId, testClassName)
+        case Some(testName) => DefaultTestMethodDescriptor(testId, testClassName, testName),
       TestStartEvent(startTime, parentId)
     )
 
@@ -122,47 +129,41 @@ final class RunTestClassProcessor(
     require(tasks.length == 1)
     val task: Task = tasks(0)
     require(TaskDefs.equal(task.taskDef, taskDef))
-
-    // see TestFilterMatch
-    val selectors: Array[Selector] = taskDef.selectors
-    val isAllTests: Boolean = arrayForAll(selectors, Selectors.isTestFromTestFilterMatch)
-    if !isAllTests then
-      require(selectors.length == 1, "If not all selectors are tests, there can only be one!")
-      val selector: Selector = selectors(0)
-      require(Selectors.equal(selector, SuiteSelector()), s"If not all selectors are tests, there can only be SuiteSelector, not $selector!")
     
     run(
       parentId = null,
-      selector = if isAllTests then SuiteSelector() else selectors(0),
-      task = task
+      selector = Selectors.fromTestFilterMatch(taskDef.selectors),
+      task = task,
+      frameworkIncludesClassNameInTestName = testClassRun.frameworkDescriptor.includesClassNameInTestName
     )
 
   private def run(
     parentId: AnyRef,
     selector: Selector,
-    task: Task
+    task: Task,
+    frameworkIncludesClassNameInTestName: Boolean
   ): Unit =
-    output(s"RunTestClassProcessor.run(${RunTestClassProcessor.toString(task)})", LogLevel.INFO)
+    output(s"RunTestClassProcessor.run(${TaskDefs.toString(task.taskDef)})", LogLevel.INFO)
 
     val startTime: Long = clock.getCurrentTime
     val testId: AnyRef = idGenerator.generateId()
     val className: String = task.taskDef.fullyQualifiedName
     
     started(
-      parentId,
-      testId,
-      className,
-      selector,
-      startTime
+      parentId = parentId,
+      testId = testId,
+      className = className,
+      selector = selector,
+      frameworkIncludesClassNameInTestName = frameworkIncludesClassNameInTestName,
+      startTime = startTime
     )
     
     try
-      output(s"RunTestClassProcessor: Task(${RunTestClassProcessor.toString(task)}).execute()", LogLevel.INFO)
-      
       val eventHandler: EventHandler = EventHandler(
         testId,
         className,
         selector,
+        frameworkIncludesClassNameInTestName,
         isAllTests = arrayForAll(task.taskDef.selectors, Selectors.isTest)
       )
       
@@ -171,11 +172,16 @@ final class RunTestClassProcessor(
         Array(testLogger(testId))
       )
       
-      arrayForEach(nestedTasks, (nestedTask: Task) => runNestedTask(
-        parentSelector = selector,
-        parentId = testId,
-        task = nestedTask
-      ))
+      arrayForEach(nestedTasks, (nestedTask: Task) =>
+        output(s"RunTestClassProcessor: nested task ${TaskDefs.toString(task.taskDef)}", LogLevel.INFO)
+
+        run(
+          parentId = testId,
+          selector = Selectors.nestedSelector(selector, nestedTask.taskDef.selectors),
+          task = nestedTask,
+          frameworkIncludesClassNameInTestName = frameworkIncludesClassNameInTestName
+        )
+      )
       
     catch case throwable@(_: NoClassDefFoundError | _: IllegalAccessError | NonFatal(_)) =>
       failure(testId, throwable)
@@ -186,40 +192,18 @@ final class RunTestClassProcessor(
         endTime = clock.getCurrentTime,
         result = null
       )
-
-  private def runNestedTask(
-    parentSelector: Selector,
-    parentId: AnyRef,
-    task: Task
-  ): Unit =
-    output(s"RunTestClassProcessor: nested task ${RunTestClassProcessor.toString(task)}", LogLevel.INFO)
-    
-    require(Selectors.canHaveNested(parentSelector), s"$parentSelector can not have nested tests!")
-    val selectors: Array[Selector] = task.taskDef.selectors
-
-    require(selectors.length == 1, "Only one selector can be nested!")
-    val selector: Selector = selectors(0)
-    
-    require(Selectors.canBeNested(selector), s"$selector can not be nested")
-    
-    run(
-      parentId = parentId,
-      selector = selector,
-      task = task
-    )
-
+  
   final private class EventHandler(
     testId: AnyRef,
     // TODO      val className: String = event.fullyQualifiedName
     className: String,
     selector: Selector,
+    frameworkIncludesClassNameInTestName: Boolean,
     isAllTests: Boolean
   ):
     // Are we running a suite or an individual test case?
     private val isRunningSuite: Boolean = Selectors.isRunningSuite(selector)
     
-    // TODO if isTests then require(isRunningSuite)
-
     // JUnit4 emits SUCCESS event for tests that were skipped because of a falsified assumption;
     // we suppress such events lest Gradle report two copies of a test - one skipped, one passed.
     private var skipped: Array[Selector] = Array.empty
@@ -227,7 +211,6 @@ final class RunTestClassProcessor(
     def handleEvent(event: Event): Unit =
       val endTime: Long = clock.getCurrentTime
       val throwable: Option[Throwable] = if event.throwable.isEmpty then None else Some(event.throwable.get)
-
       val isEventForTest: Boolean = Selectors.isEventForTest(event.selector)
 
       output(
@@ -262,14 +245,16 @@ final class RunTestClassProcessor(
         then
           def reconstructStarted(): AnyRef =
             val eventTestId: AnyRef = idGenerator.generateId()
+            
             started(
               parentId = testId,
               testId = eventTestId,
-              // attribute nested test cases to the nested, not the nesting, suite
-              className = Selectors.suiteId(event.selector).getOrElse(className),
+              className = className,
               selector = event.selector,
+              frameworkIncludesClassNameInTestName = frameworkIncludesClassNameInTestName,
               startTime = endTime - event.duration // TODO deal with negative durations?
             )
+            
             eventTestId
 
           event.status.name match
@@ -283,8 +268,3 @@ final class RunTestClassProcessor(
               skipped = arrayAppend(skipped, event.selector)
               if !isAllTests || throwable.nonEmpty || dryRun then
                 completed(reconstructStarted(), endTime, ResultType.SKIPPED)
-
-object RunTestClassProcessor:
-  val rootTestSuiteIdPlaceholder: CompositeId = CompositeId(0L, 0L)
-  
-  def toString(task: Task): String = TaskDefs.toString(task.taskDef)

--- a/src/main/scala/org/podval/tools/test/run/TracingTestResultProcessor.scala
+++ b/src/main/scala/org/podval/tools/test/run/TracingTestResultProcessor.scala
@@ -15,7 +15,7 @@ class TracingTestResultProcessor(delegate: TestResultProcessor) extends TestResu
     delegate.output(testId, event)
 
   override def started(test: TestDescriptorInternal, event: TestStartEvent): Unit =
-    trace(s"started: id=${test.getId} $test parentId=${event.getParentId} class=${test.getClass.getName} isComposite=${test.isComposite}")
+    trace(s"started: id=${test.getId} $test parentId=${event.getParentId} isComposite=${test.isComposite}")
     delegate.started(test, event)
 
   override def completed(testId: AnyRef, event: TestCompleteEvent): Unit =

--- a/src/main/scala/org/podval/tools/test/task/TestTask.scala
+++ b/src/main/scala/org/podval/tools/test/task/TestTask.scala
@@ -8,7 +8,7 @@ import org.gradle.api.internal.tasks.testing.TestFramework
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.testing.Test
-import org.gradle.api.tasks.{Internal, SourceSet, TaskAction}
+import org.gradle.api.tasks.{Internal, TaskAction}
 import org.gradle.internal.time.Clock
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.internal.{Actions, Cast}
@@ -22,8 +22,6 @@ import java.lang.reflect.Method
 // configuration: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html
 abstract class TestTask extends Test:
   setGroup(JavaBasePlugin.VERIFICATION_GROUP)
-  getDependsOn.add(Gradle.getClassesTask(getProject, sourceSetName))
-  private def sourceSetName: String = SourceSet.TEST_SOURCE_SET_NAME
 
   useSbt()
 

--- a/src/main/scala/org/podval/tools/test/taskdef/Selectors.scala
+++ b/src/main/scala/org/podval/tools/test/taskdef/Selectors.scala
@@ -1,5 +1,6 @@
 package org.podval.tools.test.taskdef
 
+import org.podval.tools.util.Scala212Collections.arrayForAll
 import sbt.testing.{NestedSuiteSelector, NestedTestSelector, Selector, SuiteSelector, TestSelector, TestWildcardSelector}
 
 // I can not rely on the test framework implementing `equals()` on `Selector`s correctly.
@@ -20,34 +21,82 @@ object Selectors extends Ops[Selector](":"):
     case "NestedTest"   => NestedTestSelector  (strings(1), strings(2))
     case "TestWildcard" => TestWildcardSelector(strings(1))
 
-  def testName(selector: Selector): Option[String] = selector match
-    case testSelector: TestSelector => Some(testSelector.testName)
-    case nestedTestSelector: NestedTestSelector => Some(nestedTestSelector.testName)
-    case _ => None
-    
-  def suiteId(selector: Selector) = selector match
-    case nestedSuiteSelector: NestedSuiteSelector => Some(nestedSuiteSelector.suiteId)
-    case nestedTestSelector: NestedTestSelector => Some(nestedTestSelector.suiteId)
-    case _ => None
-      
-  def canHaveNested(selector: Selector): Boolean = selector match
-    case _: SuiteSelector => true
-    case _: NestedSuiteSelector => true
-    case _ => false
+  // see TestFilterMatch
+  def fromTestFilterMatch(selectors: Array[Selector]): Selector =
+    val isAllTests: Boolean = arrayForAll(selectors, isTestFromTestFilterMatch)
 
-  def canBeNested(selector: Selector): Boolean = selector match
-    case _: NestedSuiteSelector => true
-    case _: NestedTestSelector => true
-    case _: TestSelector => true // ScalaCheck does this ;)
-    case _ => false
+    if !isAllTests then
+      require(selectors.length == 1, "If not all selectors are tests, there can only be one!")
+      val selector: Selector = selectors(0)
+      require(equal(selector, SuiteSelector()), s"If not all selectors are tests, there can only be SuiteSelector, not $selector!")
 
-  def isTestFromTestFilterMatch(selector: Selector): Boolean = selector match
+    if isAllTests then SuiteSelector() else selectors(0)
+
+  private def isTestFromTestFilterMatch(selector: Selector): Boolean = selector match
     case _: SuiteSelector => false
     case _: NestedSuiteSelector => throw IllegalArgumentException(s"NestedSuiteSelector can not be a part of TestFilterMatch.")
     case _: TestSelector => true
     case _: NestedTestSelector => throw IllegalArgumentException(s"NestedTestSelector can not be a part of TestFilterMatch.")
     case _: TestWildcardSelector => true
+
+  // attribute nested test cases to the nested, not the nesting, suite
+  def testClassAndTestName(
+    className: String,
+    selector: Selector,
+    frameworkIncludesClassNameInTestName: Boolean
+  ): (String, Option[String]) =
+    val suiteId: String = selector match
+      case nestedSuiteSelector: NestedSuiteSelector => nestedSuiteSelector.suiteId
+      case nestedTestSelector : NestedTestSelector  => nestedTestSelector .suiteId
+      case _ => className
+
+    selector match
+      case testSelector      : TestSelector       => Some(testSelector      .testName)
+      case nestedTestSelector: NestedTestSelector => Some(nestedTestSelector.testName)
+      case _ => None
+    match
+      case None => (suiteId, None)
+      case Some(testName) =>
+        // JUnit4 and its friends stick the class name in front of the method name;
+        // we use the class name to attribute the test to:
+        val lastDot: Int =
+          if !frameworkIncludesClassNameInTestName
+          then -1
+          else testName.lastIndexOf('.')
+        val testClassName: String =
+          if lastDot == -1
+          then suiteId
+          else testName.substring(0, lastDot)  
+        val testMethod: String =
+          if lastDot == -1
+          then testName
+          else testName.substring(lastDot + 1)
+        (testClassName, Some(testMethod))
+  
+  def nestedSelector(
+    nestingSelector: Selector,
+    nestedSelectors: Array[Selector]
+  ): Selector =
+    val canHaveNested: Boolean = nestingSelector match
+      case _: SuiteSelector => true
+      case _: NestedSuiteSelector => true
+      case _ => false
+      
+    require(canHaveNested, s"$nestingSelector can not have nested tests!")
+
+    require(nestedSelectors.length == 1, "Only one selector can be nested!")
+    val selector: Selector = nestedSelectors(0)
+
+    val canBeNested: Boolean = selector match
+      case _: NestedSuiteSelector => true
+      case _: NestedTestSelector => true
+      case _: TestSelector => true // ScalaCheck does this ;)
+      case _ => false
+      
+    require(canBeNested, s"$selector can not be nested")
     
+    selector
+  
   def isTest(selector: Selector): Boolean = selector match
     case _: SuiteSelector => false
     case _: NestedSuiteSelector => false

--- a/src/main/scala/org/podval/tools/test/taskdef/TestClassRun.scala
+++ b/src/main/scala/org/podval/tools/test/taskdef/TestClassRun.scala
@@ -10,7 +10,7 @@ abstract class TestClassRun(
 
   final override def getTestClassName: String = taskDef.fullyQualifiedName
 
-  final protected def frameworkDescriptor: FrameworkDescriptor = FrameworkDescriptor.forName(frameworkName)
+  final def frameworkDescriptor: FrameworkDescriptor = FrameworkDescriptor.forName(frameworkName)
 
   def frameworkName: String
 

--- a/src/main/scala/org/podval/tools/util/Scala212Collections.scala
+++ b/src/main/scala/org/podval/tools/util/Scala212Collections.scala
@@ -37,18 +37,6 @@ object Scala212Collections:
     val elementArray: Array[A] = new Array[A](1)
     elementArray(0) = element
     arrayConcat(array, elementArray)
-  
-  def arrayPartition[A: ClassTag](array: Array[A], p: A => Boolean): (Array[A], Array[A]) =
-    var left: Array[A] = Array.empty
-    var right: Array[A] = Array.empty
-    var i: Int = 0
-    while i < array.length do
-      val x = array(i)
-      if p(x)
-      then left  = arrayAppend(left , x)
-      else right = arrayAppend(right, x)
-      i = i + 1
-    (left, right)
 
   def arrayForAll[A](
     array: Array[A],
@@ -86,9 +74,3 @@ object Scala212Collections:
       result = result.concat(array(i))
       i = i + 1
     result.concat(end)
-
-  // methodName.stripPrefix(className + ".") is not compatible with Scala 2.12, so:
-  def stripPrefix(string: String, prefix: String): String =
-    if !string.startsWith(prefix)
-    then string
-    else string.substring(prefix.length)

--- a/src/test/scala/org/podval/tools/test/framework/FrameworksTest.scala
+++ b/src/test/scala/org/podval/tools/test/framework/FrameworksTest.scala
@@ -43,7 +43,7 @@ object FrameworksTest:
     MUnitFixture,
     ScalaCheckFixture,
     ScalaTestFixture,
-    Spec2Fixture,
+    Specs2Fixture,
     UTestFixture,
     ZioTestFixture
   )

--- a/src/test/scala/org/podval/tools/test/framework/Specs2Fixture.scala
+++ b/src/test/scala/org/podval/tools/test/framework/Specs2Fixture.scala
@@ -3,7 +3,7 @@ package org.podval.tools.test.framework
 import org.podval.tools.test.testproject.ForClass.*
 import org.podval.tools.test.testproject.{Feature, Fixture, ForClass, SourceFile}
 
-object Spec2Fixture extends Fixture(
+object Specs2Fixture extends Fixture(
   framework = org.podval.tools.test.framework.Specs2,
   testSources = Seq(SourceFile("Specs2Test",
     s"""import org.specs2._

--- a/src/test/scala/org/podval/tools/test/nested/JUnit4Fixture.scala
+++ b/src/test/scala/org/podval/tools/test/nested/JUnit4Fixture.scala
@@ -1,0 +1,46 @@
+package org.podval.tools.test.nested
+
+import org.podval.tools.test.testproject.ForClass.*
+import org.podval.tools.test.testproject.{Feature, Fixture, ForClass, SourceFile}
+
+object JUnit4Fixture extends Fixture(
+  framework = org.podval.tools.test.framework.JUnit4,
+  includeTestNames = Seq("org.podval.tools.test.JUnit4Nesting"),
+  testSources = Seq(
+    SourceFile("JUnit4Nesting",
+      s"""import org.junit.runner.RunWith
+         |import org.junit.runners.Suite
+         |
+         |@RunWith(classOf[Suite])
+         |@Suite.SuiteClasses(Array(
+         |  classOf[JUnit4Nested]
+         |))
+         |class JUnit4Nesting {
+         |}
+         |""".stripMargin
+    ),
+    SourceFile("JUnit4Nested",
+      s"""import org.junit.Test
+         |import org.junit.Assert.assertTrue
+         |
+         |final class JUnit4Nested {
+         |  @Test def success(): Unit = assertTrue("should be true", true)
+         |  @Test def failure(): Unit = assertTrue("should be true", false)
+         |}
+         |""".stripMargin
+    )
+  )
+):
+  override def checks(feature: Feature): Seq[ForClass] = feature match
+    case NestedSuitesTest.nestedSuites =>
+      Seq(
+        forClass("JUnit4Nesting",
+          // nested test cases are attributed to the nested suite
+          testCount(0)
+        ),
+        forClass("JUnit4Nested",
+          passed("success"),
+          testCount(2),
+          failedCount(1)
+        )
+      )

--- a/src/test/scala/org/podval/tools/test/nested/NestedSuitesTest.scala
+++ b/src/test/scala/org/podval/tools/test/nested/NestedSuitesTest.scala
@@ -27,13 +27,12 @@ object NestedSuitesTest:
   )
 
   val fixtures: List[Fixture] = List(
-//    JUnit4Fixture,
-//    JUnit4ScalaJSFixture,
-//    JUnit5Fixture,
+    JUnit4Fixture,
+//    JUnit4ScalaJSFixture, // does not support nested suites
 //    MUnitFixture,
 //    ScalaCheckFixture,
     ScalaTestFixture,
-//    Spec2Fixture,
+//    Specs2Fixture,
 //    UTestFixture,
 //    ZioTestFixture
   )


### PR DESCRIPTION
Mixing JVM and Scala.js (WIP):
- source set names in BackendDelegate;
- configure only source sets controlled by the delegate;
- configure `ScalaJSLinkTask`s entirely from the plugin, including their `dependOn` the classes task; they themselves are no longer aware of the name of the source set they belong to;
- same for `TestTask`;

Nested Test Suites:
- FrameworkDescriptor.additionalOptions;
- enable JUnit4's `org.junit.runners.Suite` runner needed for running nested suites and disabled by default;
- take class name prepended to the test name by some frameworks into account when attributing a test to a class;
- record which frameworks do this in `FrameworkDescriptor.includesClassNameInTestName` (JUnit4, JUnit4 for Scala.js, MUnit);
- add JUnit4 nested suite test;

fixes #54