### PR TITLE
2-Small-Bugfixes

### DIFF
--- a/src/main/scala/org/podval/tools/backend/MixedProject.scala
+++ b/src/main/scala/org/podval/tools/backend/MixedProject.scala
@@ -45,7 +45,7 @@ final class MixedProject(project: Project) extends BackendProject(project):
 
     Option.when(sourceRoot == sharedSourceRoot)(ScalaBackend.all).orElse:
       val suffix: String =
-        if sourceRoot.startsWith(sharedSourceRoot)
+        if sourceRoot.startsWith(s"$sharedSourceRoot-")
         then Strings.drop(sourceRoot, s"$sharedSourceRoot-")
         else sourceRoot
       val backendNames: Array[String] = suffix.split("-", -1)

--- a/src/main/scala/org/podval/tools/scalajs/ScalaJSLink.scala
+++ b/src/main/scala/org/podval/tools/scalajs/ScalaJSLink.scala
@@ -89,7 +89,7 @@ final class ScalaJSLink(
       .withCheckIR(fullOptimization)
       .withSemantics(if fullOptimization then Semantics.Defaults.optimized else Semantics.Defaults)
       .withModuleKind(moduleKindSJS)
-      .withClosureCompiler(fullOptimization && (moduleKind == ModuleKind.ESModule))
+      .withClosureCompiler(fullOptimization && (moduleKind != ModuleKind.ESModule))
       .withModuleSplitStyle(moduleSplitStyleSJS)
       .withExperimentalUseWebAssembly(useWebAssembly)
       .withPrettyPrint(prettyPrint)


### PR DESCRIPTION
Hi!  

First, thanks for the plugin.  
When migrating to the latest version, I noticed a couple of small bugs:  

1. **Consider `-` in suffix detection**  
The detection of `sharedProject` ignored the `-`, even though it was later used to detect the suffix.  
(In my case, I had a project with `shared` in the name that didn’t use the scalajs plugin at all. Personally, I don’t think it’s a good idea to treat projects differently based on naming conventions. But with this fix everything works as expected for me.)  
I also needed to add `evaluationDependsOn(":shared")` in one subproject. It seems the Gradle plugin sometimes assumes projects are initialized in a certain order.  

2. **Closure detection was incorrect**  
From Scala.js:  
```
require(moduleKind != ModuleKind.ESModule,
  s"Cannot use module kind $moduleKind with the Closure Compiler")
```  

Closure should be enabled when `moduleKind` is *not* `ESModule`.  
But in the plugin code, the check was the other way around: Closure was only enabled if `ESModule` was set.  

This led to the following effect: it failed with `ESModule`, and didn’t optimize when `ESModule` was not used.  

Please have a look.  
If possible, I’d appreciate an official release with these fixes soon.  
