### PR TITLE
Support for Gradle8 in addition to Gradle9

### DIFF
--- a/src/test/scala/org/podval/tools/test/testproject/TestProject.scala
+++ b/src/test/scala/org/podval/tools/test/testproject/TestProject.scala
@@ -23,6 +23,7 @@ final class TestProject(projectName: Seq[String]):
   private def gradleRunner: GradleRunner = GradleRunner
     .create
     .withProjectDir(projectDir)
+    .withGradleVersion("8.14.3")
 
   def test(commandLineIncludeTestNames: Seq[String]): TestResultsRetriever =
     // With ZIO Test on Scala.js and Scala Native, I get:


### PR DESCRIPTION
I've been just using reflection,
to fix the problem, that the GradleTeam changed the API.
It's not a nice solution - but at least it works.

For the test, for now i just hardcoded Gradle8.
But im sure it's easy to add it to the Test-Matrix with some knowledge how the tests works.